### PR TITLE
WWII - Uniforms

### DIFF
--- a/RandomPatrolGenerator.tem_anizay/database/object_db/WWII_UK.sqf
+++ b/RandomPatrolGenerator.tem_anizay/database/object_db/WWII_UK.sqf
@@ -276,7 +276,11 @@ uniformList_WWII_UK = [
 	"U_LIB_UK_P37",
 	"U_LIB_UK_P37_Corporal",
 	"U_LIB_UK_P37_LanceCorporal",
-	"U_LIB_UK_P37_Sergeant"
+	"U_LIB_UK_P37_Sergeant",
+// Winter uniforms
+	"U_LIB_UK_DenisonSmock_w",
+	"U_LIB_UK_P37Jerkins_w",
+	"U_LIB_UK_P37_w"
 ];
 
 magazineList_WWII_UK = [

--- a/RandomPatrolGenerator.tem_anizay/database/object_db/WWII_URSS.sqf
+++ b/RandomPatrolGenerator.tem_anizay/database/object_db/WWII_URSS.sqf
@@ -30,8 +30,8 @@ civilian_big_group_WWII_URSS = [
 
 civilianTruck_WWII_URSS = [
 	// Nothing to see here, Kamarad. The trucks were all taken for our glorious army.
-"LIB_GazM1", 
-"LIB_GazM1_dirty"
+	"LIB_GazM1",
+	"LIB_GazM1_dirty"
 ];
 
 //////////////////////////////
@@ -209,7 +209,8 @@ rifleList_WWII_URSS = [
 	"LIB_SVT_40",
 	"LIB_M38",
 	"LIB_M44",
-	"LIB_M9130"
+	"LIB_M9130",
+	"LIB_PTRD" // anti-material rifle, should maybe be in another list ?
 ];	
 
 launcherList_WWII_URSS = [		
@@ -336,7 +337,11 @@ uniformList_WWII_URSS = [
 	"U_LIB_SOV_Tank_sergeant",
 	"U_LIB_SOV_Tank_private_field",
 	"U_LIB_SOV_Stleutenant",
-	"U_LIB_SOV_Pilot"
+	"U_LIB_SOV_Pilot",
+// Winter uniforms start here
+	"U_LIB_SOV_Strelok_2_w",
+	"U_LIB_SOV_Strelok_w",
+	"U_LIB_SOV_Sniper_w"
 ];
 
 magazineList_WWII_URSS = [
@@ -364,5 +369,6 @@ magazineList_WWII_URSS = [
 	"LIB_47Rnd_762x54d",
 	"LIB_8Rnd_762x54",
 	"LIB_7Rnd_762x38",
-	"LIB_1Rnd_G_DYAKONOV"
+	"LIB_1Rnd_G_DYAKONOV",
+	"LIB_1Rnd_145x114" // PTRD ammo
 ];

--- a/RandomPatrolGenerator.tem_anizay/database/object_db/WWII_USA.sqf
+++ b/RandomPatrolGenerator.tem_anizay/database/object_db/WWII_USA.sqf
@@ -180,8 +180,9 @@ loadout_WWII_USA = [
 //WWII_USA
 rifleList_WWII_USA = [		
 	"LIB_M1_Carbine",
-	"LIB_M1_Garand_M7"
-
+	"LIB_M1_Garand_M7",
+	"LIB_M1903A3_Springfield",
+	"LIB_M1903A4_Springfield"
 ];	
 
 launcherList_WWII_USA = [		
@@ -189,7 +190,9 @@ launcherList_WWII_USA = [
 ];	
 
 autorifleList_WWII_USA = [	
-	"LIB_M1918A2_BAR"
+	"LIB_M1918A2_BAR",
+	"LIB_M1919A4",
+	"LIB_M1919A6"
 ];	
 
 marksmanrifleList_WWII_USA = [		
@@ -324,5 +327,10 @@ magazineList_WWII_USA = [
 	"LIB_1Rnd_89m_PIAT",
 	"LIB_1Rnd_89m_G_PIAT",
 	"LIB_32Rnd_9x19_Sten",
-	"LIB_1Rnd_G_MillsBomb"
+	"LIB_1Rnd_G_MillsBomb",
+	"LIB_50Rnd_762x63",
+	"LIB_50Rnd_762x63_M1",
+	"LIB_5Rnd_762x63",
+	"LIB_5Rnd_762x63_M1",
+	"LIB_5Rnd_762x63_t"
 ];

--- a/RandomPatrolGenerator.tem_anizay/database/object_db/WWII_USA.sqf
+++ b/RandomPatrolGenerator.tem_anizay/database/object_db/WWII_USA.sqf
@@ -266,16 +266,49 @@ backPackList_WWII_USA = [
 ];
 
 uniformList_WWII_USA = [
-	"U_LIB_UK_KhakiDrills",
-	"U_LIB_UK_DenisonSmock",
-	"U_LIB_UK_P37Jerkins",
-	"U_LIB_UK_P37Jerkins_Corporal",
-	"U_LIB_UK_P37Jerkins_LanceCorporal",
-	"U_LIB_UK_P37Jerkins_Sergeant",
-	"U_LIB_UK_P37",
-	"U_LIB_UK_P37_Corporal",
-	"U_LIB_UK_P37_LanceCorporal",
-	"U_LIB_UK_P37_Sergeant"
+	"U_LIB_US_Corp",
+	"U_LIB_US_Private_1st",
+	"U_LIB_US_Private",
+	"U_LIB_US_Sergeant",
+	"U_LIB_US_Eng",
+	"U_LIB_US_Med",
+// Rangers
+	"U_LIB_US_Rangers_Uniform",
+	"U_LIB_US_Rangers_Corp",
+	"U_LIB_US_Rangers_Private_1st",
+	"U_LIB_US_Rangers_Sergeant",
+	"U_LIB_US_Rangers_Eng",
+	"U_LIB_US_Rangers_Med",
+// North Arfican Corps
+	"U_LIB_US_NAC_Uniform",
+	"U_LIB_US_NAC_Uniform_2",
+	"U_LIB_US_NAC_Med",
+// Airborne
+	"U_LIB_US_AB_Uniform_M42",
+	"U_LIB_US_AB_Uniform_M42_506",
+	"U_LIB_US_AB_Uniform_M42_corporal",
+	"U_LIB_US_AB_Uniform_M42_FC",
+	"U_LIB_US_AB_Uniform_M42_Gas",
+	"U_LIB_US_AB_Uniform_M42_Medic",
+	"U_LIB_US_AB_Uniform_M42_NCO",
+	"U_LIB_US_AB_Uniform_M43",
+	"U_LIB_US_AB_Uniform_M43_corporal",
+	"U_LIB_US_AB_Uniform_M43_FC",
+	"U_LIB_US_AB_Uniform_M43_Flag",
+	"U_LIB_US_AB_Uniform_M43_Medic",
+	"U_LIB_US_AB_Uniform_M43_NCO",
+// Pilots
+	"U_LIB_US_Bomber_Crew",
+	"U_LIB_US_Bomber_Pilot",
+	"U_LIB_US_Pilot",
+	"U_LIB_US_Pilot_2",
+// Tank crews
+	"U_LIB_US_Tank_Crew",
+	"U_LIB_US_Tank_Crew2",
+// Winter uniforms
+	"U_LIB_US_Private_w",
+	"U_LIB_US_AB_Uniform_M42_w",
+	"U_LIB_US_AB_Uniform_M43_w"
 ];
 
 magazineList_WWII_USA = [

--- a/RandomPatrolGenerator.tem_anizay/database/object_db/WWII_Wehrmacht.sqf
+++ b/RandomPatrolGenerator.tem_anizay/database/object_db/WWII_Wehrmacht.sqf
@@ -349,7 +349,12 @@ uniformList_WWII_Wehrmacht = [
 	"U_LIB_GER_Tank_crew_unterofficer",
 	"U_LIB_GER_Spg_crew_leutnant",
 	"U_LIB_GER_Spg_crew_private",
-	"U_LIB_GER_Spg_crew_unterofficer"
+	"U_LIB_GER_Spg_crew_unterofficer",
+// Winter uniforms
+	"U_LIB_GER_Soldier3_w",
+	"U_LIB_GER_Soldier_camo_w",
+	"U_LIB_GER_Scharfschutze_w",
+	"U_LIB_GER_Scharfschutze_2_w"
 ];
 
 magazineList_WWII_Wehrmacht = [


### PR DESCRIPTION
Adding winter uniforms for UK, USA, USSR, and Wehrmacht.
Also adds the following weapons and their ammo : 
- PTRD (anti-mat rifle) for USSR
- Browning (both models) and Springfields for USA